### PR TITLE
#1 Enable indexes in Phoenix

### DIFF
--- a/hbase-standalone.env
+++ b/hbase-standalone.env
@@ -10,3 +10,4 @@ HBASE_CONF_hbase_regionserver_info_port=16030
 HBASE_CONF_hbase_zookeeper_peerport=2888
 HBASE_CONF_hbase_zookeeper_leaderport=3888
 HBASE_CONF_hbase_zookeeper_property_clientPort=2181
+HBASE_CONF_hbase_regionserver_wal_codec=org.apache.hadoop.hbase.regionserver.wal.IndexedWALEditCodec


### PR DESCRIPTION
Enable indexes by using certain property in configuration.